### PR TITLE
Cast string to integer for thumbnail height and weight attributes.

### DIFF
--- a/ets_mediaconvert_preset_v2.py
+++ b/ets_mediaconvert_preset_v2.py
@@ -815,10 +815,10 @@ def translate_thumbnails(ets_preset_payload, etsid):
 
 	##Handle Auto Resolution
 	if ets_preset_payload['Preset']['Video']['MaxWidth'] !=  'auto':
-		emf_preset_thumbnail['Settings']['VideoDescription'].update({"Width" : ets_preset_payload['Preset']['Thumbnails']['MaxWidth']})
+		emf_preset_thumbnail['Settings']['VideoDescription'].update({"Width" : int(ets_preset_payloadets_preset_payload['Preset']['Thumbnails']['MaxWidth'])})
 
 	if ets_preset_payload['Preset']['Video']['MaxHeight'] !=  'auto':
-		emf_preset_thumbnail['Settings']['VideoDescription'].update({"Height" : ets_preset_payload['Preset']['Thumbnails']['MaxHeight']})	
+		emf_preset_thumbnail['Settings']['VideoDescription'].update({"Height" : int(ets_preset_payloadets_preset_payload['Preset']['Thumbnails']['MaxHeight'])})	
 	
 	return emf_preset_thumbnail 
 


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Height and width fields must be integers, not strings (https://docs.aws.amazon.com/cli/latest/reference/mediaconvert/create-preset.html). When we use aws CLI to create a MediaConvert preset from the output of the script, we get an error because the type of the Height and Width fields is a string and not an integer. Casting to integer solves the problem.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
