### PR TITLE
add requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+boto==2.49.0
+boto3==1.12.43
+botocore==1.15.43
+docutils==0.15.2
+futures==3.3.0
+jmespath==0.9.5
+python-dateutil==2.8.1
+s3transfer==0.3.3
+six==1.14.0
+urllib3==1.25.9


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:

- creates a `requirements.txt` file containing the python requirements under which a succesful run of `ets_mediaconvert_preset_v2.py` can occur.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
