### PR TITLE
fix audio_coding variable

### DIFF
--- a/ets_mediaconvert_preset_v2.py
+++ b/ets_mediaconvert_preset_v2.py
@@ -201,9 +201,9 @@ def translate_audio(ets_preset_payload,s_audio):
         if ets_channel_num == '"2"':
             audio_coding = "CODING_MODE_2_0"
         elif ets_channel_num == '"1"':
-            audio_coding == "CODING_MODE_1_0"
+            audio_coding = "CODING_MODE_1_0"
         else:
-            audio_coding == "CODING_MODE_2_0"
+            audio_coding = "CODING_MODE_2_0"
         
         emf_bitrate = str(min(aac_range, key=lambda x:abs(x-ets_audio_bitrate)))       
         emf_bitrate = long(emf_bitrate) * 1000 


### PR DESCRIPTION
audio_coding variable is being declared with 2 equal signs , it is causing erros to converts some presets.

![2022-05-18_17-01](https://user-images.githubusercontent.com/94859997/169145807-69622dc8-755e-406a-ad9a-b7ba07095638.png)

